### PR TITLE
docs: Clarify it's an installer on Windows instructions

### DIFF
--- a/site/content/en/docs/start/_index.md
+++ b/site/content/en/docs/start/_index.md
@@ -438,7 +438,7 @@ choco install minikube
 {{% /quiz_instruction %}}
 
 {{% quiz_instruction id="/Windows/x86-64/Stable/.exe download" %}}
-1. Download the [latest release](https://storage.googleapis.com/minikube/releases/latest/minikube-installer.exe).  
+1. Download the installer of the [latest release](https://storage.googleapis.com/minikube/releases/latest/minikube-installer.exe) and run it.  
 <br>
     Or if using `PowerShell`, use this command:
     ```powershell
@@ -446,7 +446,7 @@ choco install minikube
     Invoke-WebRequest -OutFile 'c:\minikube\minikube.exe' -Uri 'https://github.com/kubernetes/minikube/releases/latest/download/minikube-windows-amd64.exe' -UseBasicParsing
     ```
 
-2. Add the binary in to your `PATH`.  
+2. Add the `minikube.exe` binary in to your `PATH`.  
 <br>
     _Make sure to run PowerShell as Administrator._
     ```powershell
@@ -459,7 +459,7 @@ choco install minikube
 {{% /quiz_instruction %}}
 
 {{% quiz_instruction id="/Windows/x86-64/Beta/.exe download" %}}
-1. Download the <a href="#" id="latest-beta-download-link">latest beta release</a>.  
+1. Download the installer of the <a href="#" id="latest-beta-download-link">latest beta release</a> and run it.  
 <br>
     Or if using `PowerShell`, use this command:
     ```powershell
@@ -470,7 +470,7 @@ choco install minikube
     Invoke-WebRequest -Uri $item.browser_download_url -OutFile 'c:\minikube\minikube.exe' -UseBasicParsing
     ```
 
-2. Add the binary in to your `PATH`.  
+2. Add the `minikube.exe` binary in to your `PATH`.  
 <br>
     _Make sure to run PowerShell as Administrator._
     ```powershell


### PR DESCRIPTION
On the installation guide for Windows, it's confusing that the link and Powershell script try downloading different binaries, the installer and the `minikube` itself.
This clarifies the link will download the installer and you should run it before step 2.